### PR TITLE
Potential fix for code scanning alert no. 75: Default version of SSL/TLS may be insecure

### DIFF
--- a/Lib/site-packages/setuptools/ssl_support.py
+++ b/Lib/site-packages/setuptools/ssl_support.py
@@ -196,8 +196,21 @@ class VerifyingHTTPSConn(HTTPSConnection):
             self.sock = ctx.wrap_socket(sock, server_hostname=actual_host)
         else:
             # This is for python < 2.7.9 and < 3.4?
+            # Explicitly use a secure protocol version when wrapping socket
+            if hasattr(ssl, 'PROTOCOL_TLSv1_2'):
+                protocol = ssl.PROTOCOL_TLSv1_2
+            elif hasattr(ssl, 'PROTOCOL_TLSv1_1'):
+                protocol = ssl.PROTOCOL_TLSv1_1
+            elif hasattr(ssl, 'PROTOCOL_TLSv1'):
+                protocol = ssl.PROTOCOL_TLSv1
+            else:
+                # fallback for very old Pythons; not secure, but best available
+                protocol = ssl.PROTOCOL_SSLv23
             self.sock = ssl.wrap_socket(
-                sock, cert_reqs=ssl.CERT_REQUIRED, ca_certs=self.ca_bundle
+                sock,
+                cert_reqs=ssl.CERT_REQUIRED,
+                ca_certs=self.ca_bundle,
+                ssl_version=protocol,
             )
         try:
             match_hostname(self.sock.getpeercert(), actual_host)


### PR DESCRIPTION
Potential fix for [https://github.com/VarshithRegonda/ecommerce/security/code-scanning/75](https://github.com/VarshithRegonda/ecommerce/security/code-scanning/75)

To securely wrap a socket when `ssl.create_default_context` is not available (i.e., legacy Python), you must explicitly pass a secure protocol to the `ssl_version` argument of `ssl.wrap_socket`. The best supported secure option for all Python versions that have `ssl.wrap_socket` is `ssl.PROTOCOL_TLSv1_2` (TLS 1.2) if available, else fallback to the most secure supported protocol. 

- In `VerifyingHTTPSConn.connect`, specifically update the call to `ssl.wrap_socket(...)` on line 199–201 to include an explicit argument: `ssl_version=ssl.PROTOCOL_TLSv1_2` (if present), or else the latest TLS protocol supported.
- This requires a check: if the legacy Python version does not support `ssl.PROTOCOL_TLSv1_2`, fallback to `ssl.PROTOCOL_TLSv1` (less secure but still better than SSL).
- Ensure no other code functionality or external interface is changed.
- No additional imports are required since all protocol constants come from the `ssl` module.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
