### PR TITLE
Potential fix for code scanning alert no. 50: Incomplete multi-character sanitization

### DIFF
--- a/static_in_env/js/addons/datatables.js
+++ b/static_in_env/js/addons/datatables.js
@@ -14805,11 +14805,18 @@
 	
 		// html
 		"html-pre": function ( a ) {
-			return _empty(a) ?
-				'' :
-				a.replace ?
-					a.replace( /<.*?>/g, "" ).toLowerCase() :
-					a+'';
+			if (_empty(a)) {
+				return '';
+			}
+			if (a.replace) {
+				let prev, cur = a;
+				do {
+					prev = cur;
+					cur = cur.replace(/<.*?>/g, "");
+				} while (cur !== prev);
+				return cur.toLowerCase();
+			}
+			return a + '';
 		},
 	
 		// string


### PR DESCRIPTION
Potential fix for [https://github.com/VarshithRegonda/ecommerce/security/code-scanning/50](https://github.com/VarshithRegonda/ecommerce/security/code-scanning/50)

To fix this issue, you should avoid using a single regex pass like `/\<.*?\>/g` to strip HTML tags, as it can miss malicious input or fail in edge cases (e.g., nested or malformed tags, or tags broken up for evasion). The best fix, given restriction to the shown code, is to repeatedly apply the replacement until no more changes occur, ensuring all instances are stripped even after replacement alters the string. Alternatively, you could use a more robust HTML parsing/sanitization library (like `sanitize-html`), but this is not possible without changing the context (vanilla in-browser JS, no imports shown or permitted). 

Therefore, patch the `"html-pre"` function so that it strips tags repeatedly using a loop, similar to the canonical fix described in the background. The change should be in the `static_in_env/js/addons/datatables.js` file, specifically lines 14807-14813.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
