### PR TITLE
Potential fix for code scanning alert no. 81: Use of insecure SSL/TLS version

### DIFF
--- a/Lib/site-packages/setuptools/ssl_support.py
+++ b/Lib/site-packages/setuptools/ssl_support.py
@@ -196,16 +196,14 @@ class VerifyingHTTPSConn(HTTPSConnection):
             self.sock = ctx.wrap_socket(sock, server_hostname=actual_host)
         else:
             # This is for python < 2.7.9 and < 3.4?
-            # Explicitly use a secure protocol version when wrapping socket
+            # Only support TLSv1_2 (minimum secure protocol). Error if unavailable.
             if hasattr(ssl, 'PROTOCOL_TLSv1_2'):
                 protocol = ssl.PROTOCOL_TLSv1_2
-            elif hasattr(ssl, 'PROTOCOL_TLSv1_1'):
-                protocol = ssl.PROTOCOL_TLSv1_1
-            elif hasattr(ssl, 'PROTOCOL_TLSv1'):
-                protocol = ssl.PROTOCOL_TLSv1
             else:
-                # fallback for very old Pythons; not secure, but best available
-                protocol = ssl.PROTOCOL_SSLv23
+                raise RuntimeError(
+                    "A minimum of TLSv1.2 is required to establish a secure "
+                    "connection, but your Python/SSL does not support it."
+                )
             self.sock = ssl.wrap_socket(
                 sock,
                 cert_reqs=ssl.CERT_REQUIRED,


### PR DESCRIPTION
Potential fix for [https://github.com/VarshithRegonda/ecommerce/security/code-scanning/81](https://github.com/VarshithRegonda/ecommerce/security/code-scanning/81)

To fix the vulnerability, we must prevent the use of protocol versions lower than TLS 1.2. This means that, even as a fallback, the minimum protocol used must be TLS 1.2 (`ssl.PROTOCOL_TLSv1_2`). If this protocol is not available (as in very old Python or OpenSSL installations), it may be best to raise an error rather than permit a connection with a known-insecure protocol. The code should therefore try to use a context (via `ssl.create_default_context` or, if not available, a context with `ssl.PROTOCOL_TLSv1_2`) and no longer attempt to use `PROTOCOL_TLSv1_1`, `PROTOCOL_TLSv1`, or `PROTOCOL_SSLv23`. Update the relevant code block in `VerifyingHTTPSConn.connect()` within `Lib/site-packages/setuptools/ssl_support.py` (lines 194–215), ensuring only TLS 1.2+ is permitted.

No new methods are needed. However, a `RuntimeError` should be raised if neither `ssl.create_default_context` nor `ssl.PROTOCOL_TLSv1_2` are available, informing the user that their environment is too old and insecure for a TLS connection.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
