### PR TITLE
Potential fix for code scanning alert no. 82: Use of insecure SSL/TLS version

### DIFF
--- a/Lib/site-packages/setuptools/ssl_support.py
+++ b/Lib/site-packages/setuptools/ssl_support.py
@@ -193,8 +193,15 @@ class VerifyingHTTPSConn(HTTPSConnection):
 
         if hasattr(ssl, 'create_default_context'):
             ctx = ssl.create_default_context(cafile=self.ca_bundle)
+            # Ensure only secure protocols: restrict to TLSv1.2 and higher if possible
+            if hasattr(ctx, "minimum_version") and hasattr(ssl, "TLSVersion"):
+                ctx.minimum_version = ssl.TLSVersion.TLSv1_2
+            else:
+                # For Python versions without minimum_version, disable TLSv1 and TLSv1.1 using options if available
+                if hasattr(ssl, "OP_NO_TLSv1") and hasattr(ssl, "OP_NO_TLSv1_1"):
+                    ctx.options |= getattr(ssl, "OP_NO_TLSv1")
+                    ctx.options |= getattr(ssl, "OP_NO_TLSv1_1")
             self.sock = ctx.wrap_socket(sock, server_hostname=actual_host)
-        else:
             # This is for python < 2.7.9 and < 3.4?
             # Only support TLSv1_2 (minimum secure protocol). Error if unavailable.
             if hasattr(ssl, 'PROTOCOL_TLSv1_2'):


### PR DESCRIPTION
Potential fix for [https://github.com/VarshithRegonda/ecommerce/security/code-scanning/82](https://github.com/VarshithRegonda/ecommerce/security/code-scanning/82)

The problem is that when creating a context with `ssl.create_default_context`, the code does not explicitly set either `context.options` to disable old TLS versions, nor does it set `context.minimum_version`, which is the modern way to restrict to only secure protocols (TLS 1.2+). The fix is to set `ctx.minimum_version = ssl.TLSVersion.TLSv1_2` after creating the context. Because some older Python versions don’t have `SSLContext.minimum_version` or `TLSVersion`, the code should check for their presence before assigning, and (optionally, but recommended) fall back to setting `ctx.options` to disable TLSv1 and TLSv1.1 using bitwise flags if needed. This preserves functionality for old Pythons and ensures new ones are locked down.

All changes should be within the Lib/site-packages/setuptools/ssl_support.py file, specifically in the `VerifyingHTTPSConn.connect` method, after initializing `ctx = ssl.create_default_context(...)`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
