### PR TITLE
Potential fix for code scanning alert no. 83: Use of insecure SSL/TLS version

### DIFF
--- a/Lib/site-packages/setuptools/ssl_support.py
+++ b/Lib/site-packages/setuptools/ssl_support.py
@@ -193,7 +193,7 @@ class VerifyingHTTPSConn(HTTPSConnection):
 
         if hasattr(ssl, 'create_default_context'):
             ctx = ssl.create_default_context(cafile=self.ca_bundle)
-            # Ensure only secure protocols: restrict to TLSv1.2 and higher if possible
+            # Always enforce TLSv1.2+ explicitly
             if hasattr(ctx, "minimum_version") and hasattr(ssl, "TLSVersion"):
                 ctx.minimum_version = ssl.TLSVersion.TLSv1_2
             else:
@@ -201,22 +201,13 @@ class VerifyingHTTPSConn(HTTPSConnection):
                 if hasattr(ssl, "OP_NO_TLSv1") and hasattr(ssl, "OP_NO_TLSv1_1"):
                     ctx.options |= getattr(ssl, "OP_NO_TLSv1")
                     ctx.options |= getattr(ssl, "OP_NO_TLSv1_1")
+                else:
+                    # No way to restrict old SSL/TLS versions; abort
+                    raise RuntimeError(
+                        "Cannot enforce minimum TLSv1.2 for HTTPS connection: your Python/SSL does not support protocol restriction options."
+                    )
+            # Only wrap once, safely restricted
             self.sock = ctx.wrap_socket(sock, server_hostname=actual_host)
-            # This is for python < 2.7.9 and < 3.4?
-            # Only support TLSv1_2 (minimum secure protocol). Error if unavailable.
-            if hasattr(ssl, 'PROTOCOL_TLSv1_2'):
-                protocol = ssl.PROTOCOL_TLSv1_2
-            else:
-                raise RuntimeError(
-                    "A minimum of TLSv1.2 is required to establish a secure "
-                    "connection, but your Python/SSL does not support it."
-                )
-            self.sock = ssl.wrap_socket(
-                sock,
-                cert_reqs=ssl.CERT_REQUIRED,
-                ca_certs=self.ca_bundle,
-                ssl_version=protocol,
-            )
         try:
             match_hostname(self.sock.getpeercert(), actual_host)
         except CertificateError:


### PR DESCRIPTION
Potential fix for [https://github.com/VarshithRegonda/ecommerce/security/code-scanning/83](https://github.com/VarshithRegonda/ecommerce/security/code-scanning/83)

The fix should ensure that any context created and used for SSL/TLS connections *only* allows modern/secure protocol versions (TLSv1.2 and higher).  
Specifically:
- After creating `ctx` via `ssl.create_default_context`, the code should always set `minimum_version = TLSv1_2` if available (Python 3.7+), or always set disabling flags (`OP_NO_TLSv1`, `OP_NO_TLSv1_1`) if `minimum_version` is not available, *without making this conditional on context wrapping path selection*.
- Use only a single wrapping call (avoid double-wrapping).
- Remove ambiguity by having `self.sock = ...` assigned only once per execution, after the appropriate restrictions have been applied.
- In short, always restrict connection protocols, and ensure that the code cannot accidentally allow insecure versions.

**File/region to change:**  
Edit lines 194–219 in Lib/site-packages/setuptools/ssl_support.py.  
- Ensure protocol restrictions are always set before wrapping the socket.
- Remove the legacy double-wrapping (`ctx.wrap_socket` and then again with `ssl.wrap_socket`) logic.
- Ensure fallback raises an error if TLSv1.2 cannot be enforced.

**Required changes:**  
- Set protocol restrictions immediately after context creation.
- Only wrap the socket once.
- Remove legacy fallback unless strictly needed, and if so ensure it enforces TLSv1.2.
- No external dependencies are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
