### PR TITLE
Potential fix for code scanning alert no. 74: Default version of SSL/TLS may be insecure

### DIFF
--- a/Lib/site-packages/pip/_vendor/urllib3/util/ssl_.py
+++ b/Lib/site-packages/pip/_vendor/urllib3/util/ssl_.py
@@ -105,7 +105,17 @@ except ImportError:
 
     class SSLContext(object):  # Platform-specific: Python 2
         def __init__(self, protocol_version):
-            self.protocol = protocol_version
+            # If protocol_version is None, select the most secure available protocol
+            if protocol_version is None:
+                if hasattr(ssl, "PROTOCOL_TLSv1_2"):
+                    self.protocol = ssl.PROTOCOL_TLSv1_2
+                elif hasattr(ssl, "PROTOCOL_TLS"):
+                    self.protocol = ssl.PROTOCOL_TLS
+                else:
+                    # Fallback, warn via comment. User will get further warnings.
+                    self.protocol = ssl.PROTOCOL_SSLv23
+            else:
+                self.protocol = protocol_version
             # Use default values from a real SSLContext
             self.check_hostname = False
             self.verify_mode = ssl.CERT_NONE


### PR DESCRIPTION
Potential fix for [https://github.com/VarshithRegonda/ecommerce/security/code-scanning/74](https://github.com/VarshithRegonda/ecommerce/security/code-scanning/74)

To fix the problem, ensure that the minimal `SSLContext` fallback always uses a safe and modern protocol by default, ideally TLSv1.2 if available. Modify the `__init__` method so that if no explicit `protocol_version` is given (or if it is `None`), it attempts to select the best available protocol: prefer `PROTOCOL_TLSv1_2`, fall back to `PROTOCOL_TLS`, and only then to the less secure alternatives (with an appropriate warning/warning comment).

The code to import `ssl` and discover which protocol constants are available must only use existing imports, but direct use of the `ssl` module is present in this file, so no new import is needed.

Specifically, in the `SSLContext.__init__` method, detect if `protocol_version` is `None`, and pick the strongest available. Only change within the shown snippet: do not alter how the rest of the code instantiates or calls this class.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
