### PR TITLE
Potential fix for code scanning alert no. 73: Use of insecure SSL/TLS version

### DIFF
--- a/Lib/site-packages/pip/_vendor/distlib/util.py
+++ b/Lib/site-packages/pip/_vendor/distlib/util.py
@@ -1434,12 +1434,20 @@ if ssl:
                     cert_reqs = ssl.CERT_NONE
                 self.sock = ssl.wrap_socket(sock, self.key_file, self.cert_file,
                                             cert_reqs=cert_reqs,
-                                            ssl_version=ssl.PROTOCOL_SSLv23,
+                                            ssl_version=getattr(ssl, 'PROTOCOL_TLSv1_2', ssl.PROTOCOL_TLS),
                                             ca_certs=self.ca_certs)
             else:  # pragma: no cover
-                context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
+                context = ssl.SSLContext(getattr(ssl, 'PROTOCOL_TLSv1_2', ssl.PROTOCOL_TLS))
+                # Disable insecure protocols if available
                 if hasattr(ssl, 'OP_NO_SSLv2'):
                     context.options |= ssl.OP_NO_SSLv2
+                if hasattr(ssl, 'OP_NO_TLSv1'):
+                    context.options |= ssl.OP_NO_TLSv1
+                if hasattr(ssl, 'OP_NO_TLSv1_1'):
+                    context.options |= ssl.OP_NO_TLSv1_1
+                # For Python 3.7+, set recommended minimum_version
+                if hasattr(context, 'minimum_version') and hasattr(ssl, 'TLSVersion'):
+                    context.minimum_version = ssl.TLSVersion.TLSv1_2
                 if self.cert_file:
                     context.load_cert_chain(self.cert_file, self.key_file)
                 kwargs = {}


### PR DESCRIPTION
Potential fix for [https://github.com/VarshithRegonda/ecommerce/security/code-scanning/73](https://github.com/VarshithRegonda/ecommerce/security/code-scanning/73)

To address the issue, restrict the SSL/TLS protocol version used to TLSv1.2 or higher. The best way to do this is:

- For Python versions that support `ssl.PROTOCOL_TLSv1_2`, use it in both `ssl.SSLContext` and `ssl.wrap_socket`.
- For Python 3.7+, use the convenient `minimum_version` attribute on an SSLContext, setting it to `ssl.TLSVersion.TLSv1_2`.
- Disable insecure protocols by setting the context options `OP_NO_TLSv1` and `OP_NO_TLSv1_1` if these are available, as additional defense (for Python 3.2+).
- Make minimal changes: only replace the protocol argument in both lines 1437 and 1440, and add safeguards for older Python versions that may not have newer features by conditionally setting options if possible.

This change needs to be made in the code block implementing the `HTTPSConnection.connect` method (lines 1437 and 1440), with supporting conditional logic for version compatibility. Imports and other code outside this function do not need to change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
