### PR TITLE
Potential fix for code scanning alert no. 71: Use of insecure SSL/TLS version

### DIFF
--- a/Lib/site-packages/pip/_vendor/urllib3/util/ssl_.py
+++ b/Lib/site-packages/pip/_vendor/urllib3/util/ssl_.py
@@ -265,6 +265,18 @@ def create_urllib3_context(
     """
     context = SSLContext(ssl_version or PROTOCOL_TLS)
 
+    # Ensure only secure TLS protocols are permitted
+    # For Python 3.7+, use minimum_version
+    import ssl
+    if hasattr(context, "minimum_version"):
+        try:
+            context.minimum_version = ssl.TLSVersion.TLSv1_2
+        except AttributeError:
+            # TLSVersion may not exist on very old Python
+            context.options |= getattr(ssl, "OP_NO_TLSv1", 0) | getattr(ssl, "OP_NO_TLSv1_1", 0)
+    else:
+        context.options |= getattr(ssl, "OP_NO_TLSv1", 0) | getattr(ssl, "OP_NO_TLSv1_1", 0)
+
     context.set_ciphers(ciphers or DEFAULT_CIPHERS)
 
     # Setting the default here, as we may have no ssl module on import


### PR DESCRIPTION
Potential fix for [https://github.com/VarshithRegonda/ecommerce/security/code-scanning/71](https://github.com/VarshithRegonda/ecommerce/security/code-scanning/71)

To remedy the issue, ensure that when constructing the SSLContext, connections are limited to TLSv1.2 and above. The ideal fix depends on the Python version:

- For Python 3.7+: set `context.minimum_version = ssl.TLSVersion.TLSv1_2`.
- For Python 3.2+: set `context.options |= ssl.OP_NO_TLSv1 | ssl.OP_NO_TLSv1_1`.
- For older Python: Do as much as possible to disable insecure protocols via options, but recommend upgrades.

You are only able to modify the code in the file shown. On line 266, after the context is created, you should:
- Add logic to set `minimum_version` if possible (using `hasattr` or via version detection).
- Set `context.options |= ssl.OP_NO_TLSv1 | ssl.OP_NO_TLSv1_1` to disable TLSv1 and TLSv1_1 for backward compatibility.

You may need to import or reference `ssl` if not already in the current scope. The best placement for the fix is immediately after the context is created and before further customizations.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
