### PR TITLE
Potential fix for code scanning alert no. 66: Incomplete URL substring sanitization

### DIFF
--- a/Lib/site-packages/setuptools/command/upload_docs.py
+++ b/Lib/site-packages/setuptools/command/upload_docs.py
@@ -68,7 +68,8 @@ class upload_docs(upload):
         else:
             self.ensure_dirname('upload_dir')
             self.target_dir = self.upload_dir
-        if 'pypi.python.org' in self.repository:
+        repo_url = urllib.parse.urlparse(self.repository)
+        if repo_url.hostname == "pypi.python.org":
             log.warn("Upload_docs command is deprecated. Use RTD instead.")
         self.announce('Using upload directory %s' % self.target_dir)
 


### PR DESCRIPTION
Potential fix for [https://github.com/VarshithRegonda/ecommerce/security/code-scanning/66](https://github.com/VarshithRegonda/ecommerce/security/code-scanning/66)

The correct way to address this problem is to parse the URL and explicitly check the hostname (netloc) part, ensuring the repository points to `pypi.python.org` (or possibly a specific set of allowed hosts, if required). In this context, instead of the substring test, we should use `urllib.parse` to extract the hostname, then compare it precisely. Since the rest of the codebase uses `self.repository`, we will parse it with `urllib.parse.urlparse`, extract the relevant netloc/hostname, and compare to `'pypi.python.org'`.

Edit: In `Lib/site-packages/setuptools/command/upload_docs.py`, update line 71 (and possibly add an import for `urllib.parse` or use the already-imported `urllib` from `setuptools.extern.six.moves`).

Steps:
- Instead of `'pypi.python.org' in self.repository`, parse the repository URL.
- Extract the hostname and compare: `hostname == "pypi.python.org"`.
- If `urllib.parse`/`urllib` is not imported, use `from setuptools.extern.six.moves import urllib` as already present.
- No additional dependencies or code outside the provided file are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
