### PR TITLE
Potential fix for code scanning alert no. 65: Incomplete URL substring sanitization

### DIFF
--- a/Lib/site-packages/pip/_vendor/distlib/locators.py
+++ b/Lib/site-packages/pip/_vendor/distlib/locators.py
@@ -197,7 +197,8 @@ class Locator(object):
         is_downloadable = basename.endswith(self.downloadable_extensions)
         if is_wheel:
             compatible = is_compatible(Wheel(basename), self.wheel_tags)
-        return (t.scheme == 'https', 'pypi.org' in t.netloc,
+        is_pypi_host = (t.hostname == 'pypi.org') or (t.hostname and t.hostname.endswith('.pypi.org'))
+        return (t.scheme == 'https', is_pypi_host,
                 is_downloadable, is_wheel, compatible, basename)
 
     def prefer_url(self, url1, url2):


### PR DESCRIPTION
Potential fix for [https://github.com/VarshithRegonda/ecommerce/security/code-scanning/65](https://github.com/VarshithRegonda/ecommerce/security/code-scanning/65)

To properly check whether a URL points to `pypi.org` (or its subdomains), parse the URL and extract its host (`t.hostname` using `urlparse`). Then, verify whether the hostname is exactly `'pypi.org'` or ends with `'.pypi.org'` (the leading dot prevents matches like `notpypi.org`). This approach works for both apex domains and subdomains, as recommended.

**Changes required:**
- In `score_url`, replace `'pypi.org' in t.netloc` with a safe check using `t.hostname`.
- Ensure any subdomain of `pypi.org` matches, but not domains like `bad-pypi.org.evil.com`.
- If `t.hostname` is None, treat as not matching.

No new external imports are needed, since `urlparse` and host handling are already present.

Edit only the check for host matching on line 200 in `Lib/site-packages/pip/_vendor/distlib/locators.py`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
