### PR TITLE
Potential fix for code scanning alert no. 48: Incomplete multi-character sanitization

### DIFF
--- a/static_in_env/js/addons/datatables.js
+++ b/static_in_env/js/addons/datatables.js
@@ -6057,6 +6057,16 @@
 	}
 	
 	
+	// Improved tag remover for sTitle
+	function stripTags(s) {
+		var prev;
+		do {
+			prev = s;
+			s = s.replace(/<.*?>/g, "");
+		} while (s !== prev);
+		return s;
+	}
+
 	function _fnSortAria ( settings )
 	{
 		var label;
@@ -6071,7 +6081,7 @@
 		{
 			var col = columns[i];
 			var asSorting = col.asSorting;
-			var sTitle = col.sTitle.replace( /<.*?>/g, "" );
+			var sTitle = stripTags(col.sTitle);
 			var th = col.nTh;
 	
 			// IE7 is throwing an error when setting these properties with jQuery's


### PR DESCRIPTION
Potential fix for [https://github.com/VarshithRegonda/ecommerce/security/code-scanning/48](https://github.com/VarshithRegonda/ecommerce/security/code-scanning/48)

The best way to fix this issue is to ensure *all* HTML tags are removed robustly from `col.sTitle`, not just simple tags.  
- The current regex does not reliably remove all tags or fragments (e.g., `<script`, `<img ...`, nested tags, malformed tags).
- The ideal solution is to use a well-maintained library such as `sanitize-html`. This would require a dependency, which may not be acceptable for this file.  
- Alternatively, use a safer, more robust regular expression such as replacing all `<` and `>` characters: `/<|>/g`. If that's too aggressive (and legitimate `<`/`>` may appear), consider also repeatedly applying the original regex until no more changes occur, as in the recommended fix:  
    ```
    function stripTags(s) {
      let prev;
      do {
        prev = s;
        s = s.replace(/<.*?>/g, "");
      } while (s !== prev);
      return s;
    }
    ```
- For the specific file and context (`static_in_env/js/addons/datatables.js`, line 6074),  
  -- Insert a helper function above `_fnSortAria`: `function stripTags(s) ...`  
  -- Replace `col.sTitle.replace( /<.*?>/g, "" );` with `stripTags(col.sTitle);`  
  -- No additional imports are needed for a helper function.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
