### PR TITLE
Potential fix for code scanning alert no. 63: Clear-text logging of sensitive information

### DIFF
--- a/Lib/warnings.py
+++ b/Lib/warnings.py
@@ -1,7 +1,7 @@
 """Python part of the warnings subsystem."""
 
 import sys
-
+import re
 
 __all__ = ["warn", "warn_explicit", "showwarning",
            "formatwarning", "filterwarnings", "simplefilter",
@@ -16,6 +16,14 @@ def formatwarning(message, category, filename, lineno, line=None):
     """Function to format a warning the standard way."""
     msg = WarningMessage(message, category, filename, lineno, None, line)
     return _formatwarnmsg_impl(msg)
+def sanitize_warning_text(text):
+    # Redact password=... (case-insensitive), password: ..., or Authorization headers
+    text = re.sub(r'(?i)(password\s*[=:]\s*)([^\s,;\'"]+)', r'\1<redacted>', text)
+    # Redact Authorization: Basic ... credentials (typical pattern)
+    text = re.sub(r'(Authorization:\s*Basic\s+)([A-Za-z0-9+/=]+)', r'\1<redacted>', text, flags=re.IGNORECASE)
+    # If other secrets/credentials patterns are needed, add here
+    return text
+
 
 def _showwarnmsg_impl(msg):
     file = msg.file
@@ -25,6 +33,7 @@ def _showwarnmsg_impl(msg):
             # sys.stderr is None when run with pythonw.exe:
             # warnings get lost
             return
+    text = sanitize_warning_text(text)
     text = _formatwarnmsg(msg)
     try:
         file.write(text)


### PR DESCRIPTION
Potential fix for [https://github.com/VarshithRegonda/ecommerce/security/code-scanning/63](https://github.com/VarshithRegonda/ecommerce/security/code-scanning/63)

To mitigate the risk of leaking sensitive data via the warnings subsystem, we should sanitize the warning message before it is written to output. The best fix is to redact (remove or obfuscate) likely credentials from warning text just before writing it to logs. Since we may not reliably distinguish every kind of sensitive data, and because we do not want to break legacy usage, we will specifically target known patterns that often contain credentials (e.g., "password=" or "Authorization: Basic ..."). For high-confidence mitigation, we should scan the warning text for known patterns of credentials and replace them with placeholders (e.g., `<redacted>`). The filtering must be added just before writing (in `_showwarnmsg_impl`, before `file.write(text)`).

We will add a helper function, `sanitize_warning_text`, which will use regular expressions to detect (and redact) values for keys such as "password=", "Password:", and HTTP basic auth headers. We will also import the `re` module for this purpose. The function will be called on the warning message just before it is written to the output stream.

Change required:
- In `Lib/warnings.py`, add a `sanitize_warning_text(text)` function.
- Import the `re` module.
- In `_showwarnmsg_impl`, call `sanitize_warning_text(text)` just before writing to file.
- Do not change the warning format or logic elsewhere.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
