### PR TITLE
Potential fix for code scanning alert no. 62: Clear-text logging of sensitive information

### DIFF
--- a/Lib/site-packages/pip/_internal/network/session.py
+++ b/Lib/site-packages/pip/_internal/network/session.py
@@ -13,7 +13,7 @@ import os
 import platform
 import sys
 import warnings
-
+import hashlib
 from pip._vendor import requests, six, urllib3
 from pip._vendor.cachecontrol import CacheControlAdapter
 from pip._vendor.requests.adapters import BaseAdapter, HTTPAdapter
@@ -301,9 +301,11 @@ class PipSession(requests.Session):
             string came from.
         """
         if not suppress_logging:
-            msg = 'adding trusted host: {!r}'.format(host)
+            # Compute a SHA-256 digest of the host string
+            host_digest = hashlib.sha256(host.encode("utf-8")).hexdigest()[:8]
+            msg = f"adding trusted host with digest: {host_digest!r}"
             if source is not None:
-                msg += ' (from {})'.format(source)
+                msg += f" (from {source})"
             logger.info(msg)
 
         host_port = parse_netloc(host)


### PR DESCRIPTION
Potential fix for [https://github.com/VarshithRegonda/ecommerce/security/code-scanning/62](https://github.com/VarshithRegonda/ecommerce/security/code-scanning/62)

To fix the problem, we must avoid logging the full user-supplied value for `host` as clear text. The ideal fix is to sanitize the logged data to ensure no sensitive information is exposed. 

Specifically, in the `add_trusted_host` method:
- Instead of logging the full `host`, log a hashed or redacted version that allows debugging/auditing without exposing the actual value.
- Use a cryptographic hash (e.g., SHA-256) to log a digest of the hostname, not the actual detail. Mathematical hashes are preferable over redaction because they allow correlation in logs (the same value always produces the same digest) but do not reveal the secret.
- We should add the import for `hashlib` at the top of the file and update the logging statement.

The fix is localized to `Lib/site-packages/pip/_internal/network/session.py` lines 303–308. Update the logging statement to log a truncated SHA-256 hexdigest for the host value instead of the raw host.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
