### PR TITLE
Potential fix for code scanning alert no. 61: Clear-text logging of sensitive information

### DIFF
--- a/Lib/site-packages/pip/_internal/self_outdated_check.py
+++ b/Lib/site-packages/pip/_internal/self_outdated_check.py
@@ -60,7 +60,7 @@ def make_link_collector(
     if options.no_index and not suppress_no_index:
         logger.debug(
             'Ignoring indexes: %s',
-            ','.join(redact_auth_from_url(url) for url in index_urls),
+            ','.join(remove_auth_from_url(url) for url in index_urls),
         )
         index_urls = []
 


### PR DESCRIPTION
Potential fix for [https://github.com/VarshithRegonda/ecommerce/security/code-scanning/61](https://github.com/VarshithRegonda/ecommerce/security/code-scanning/61)

To fully avoid logging sensitive data, including usernames as well as passwords and access tokens (sometimes stored as the username with blank passwords), we should ensure that not just the password, but also the username (and tokens) are redacted before logging URLs. A secure approach is to log only the hostname part of the URLs (e.g., removing credentials entirely), or to use a more robust utility that strips all authentication information from URLs before logging. In `Lib/site-packages/pip/_internal/self_outdated_check.py`, line 63, replace the use of `redact_auth_from_url` with `remove_auth_from_url`, which removes the entire username:password part before the "@" in the URL. Make this change only at the affected logging call—since the rest of the functionality expects URLs with credentials, only the logged representation can be altered.

No new imports are required, as `remove_auth_from_url` is already available from the same `pip._internal.utils.misc` import block used for `redact_auth_from_url`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
