### PR TITLE
Potential fix for code scanning alert no. 60: Clear-text logging of sensitive information

### DIFF
--- a/Lib/site-packages/pip/_internal/utils/misc.py
+++ b/Lib/site-packages/pip/_internal/utils/misc.py
@@ -707,21 +707,14 @@ def redact_netloc(netloc):
     Replace the sensitive data in a netloc with "****", if it exists.
 
     For example:
-        - "user:pass@example.com" returns "user:****@example.com"
+        - "user:pass@example.com" returns "****@example.com"
         - "accesstoken@example.com" returns "****@example.com"
     """
     netloc, (user, password) = split_auth_from_netloc(netloc)
-    if user is None:
+    if user is None and password is None:
         return netloc
-    if password is None:
-        user = '****'
-        password = ''
-    else:
-        user = urllib_parse.quote(user)
-        password = ':****'
-    return '{user}{password}@{netloc}'.format(user=user,
-                                              password=password,
-                                              netloc=netloc)
+    # If either user or password is present, redact both as ****
+    return '****@{netloc}'.format(netloc=netloc)
 
 
 def _transform_url(url, transform_netloc):


### PR DESCRIPTION
Potential fix for [https://github.com/VarshithRegonda/ecommerce/security/code-scanning/60](https://github.com/VarshithRegonda/ecommerce/security/code-scanning/60)

To fully prevent clear-text logging of authentication tokens or usernames, we should update the redaction logic to always fully replace both username and password fields with asterisks ("****") whenever authentication information is present in the URL's netloc part—regardless of whether a password is provided. The function `redact_netloc` in `pip/_internal/utils/misc.py` currently only replaces the username when the password is absent, but may leave "user:****" in logs; we should ensure that `"****"` is always emitted instead of any real value.

#### Steps:
1. In `redact_netloc`, update the handling so that, if either a username or password is present in the URL, both fields are replaced with `"****"`.
2. Always emit a netloc that looks like `"****@hostname"`, whether the credentials are supplied as `user@host`, `user:pass@host`, or `:pass@host`.
3. This prevents leaking tokens that might be provided as "username" in the URL (as in PyPI's API token usage).

**Required changes**:
- Edit the `redact_netloc` function in `Lib/site-packages/pip/_internal/utils/misc.py`, lines 704–724.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
