### PR TITLE
Potential fix for code scanning alert no. 47: Incomplete multi-character sanitization

### DIFF
--- a/static_in_env/js/addons/datatables.js
+++ b/static_in_env/js/addons/datatables.js
@@ -5820,7 +5820,11 @@
 	
 		for ( var i=0, ien=settings.aoData.length ; i<ien ; i++ ) {
 			s = _fnGetCellData( settings, i, colIdx, 'display' )+'';
-			s = s.replace( __re_html_remove, '' );
+			// Repeatedly remove HTML tags until fully sanitized
+			do {
+				var oldS = s;
+				s = s.replace( __re_html_remove, '' );
+			} while (s !== oldS);
 			s = s.replace( /&nbsp;/g, ' ' );
 	
 			if ( s.length > max ) {


### PR DESCRIPTION
Potential fix for [https://github.com/VarshithRegonda/ecommerce/security/code-scanning/47](https://github.com/VarshithRegonda/ecommerce/security/code-scanning/47)

To address this issue, the sanitization logic for stripping HTML tags (currently using `s.replace( __re_html_remove, '' )`) should be improved to completely remove any HTML tags, even in cases where tags may be nested or split, and to prevent incomplete removal of malicious patterns like `<script>`. Since the existing regular expression may fail in edge cases (see background), one robust general fix is to repeatedly apply the regex replacement until the input no longer changes, ensuring all possibly overlapping or consecutively formed tags are removed. In this file, the problematic replacement is found in `_fnGetMaxLenString`, so the replacement should be changed to do a repeated replacement loop, as per the background recommendation.

The only code needing change is the single-line sanitization in `_fnGetMaxLenString`. No new imports are required. No new definitions or functions are required in this limited context; an in-place loop is sufficient.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
