### PR TITLE
Potential fix for code scanning alert no. 43: Incomplete multi-character sanitization

### DIFF
--- a/Ecommerce-Template-Bootstrap-master/Ecommerce-Template-Bootstrap-master/js/addons/datatables.js
+++ b/Ecommerce-Template-Bootstrap-master/Ecommerce-Template-Bootstrap-master/js/addons/datatables.js
@@ -6057,6 +6057,16 @@
 	}
 	
 	
+	// Robust HTML tag stripper
+	function _stripTags(s) {
+		let old;
+		do {
+			old = s;
+			s = s.replace(/<.*?>/g, "");
+		} while (s !== old);
+		return s;
+	}
+	
 	function _fnSortAria ( settings )
 	{
 		var label;
@@ -6071,7 +6081,7 @@
 		{
 			var col = columns[i];
 			var asSorting = col.asSorting;
-			var sTitle = col.sTitle.replace( /<.*?>/g, "" );
+			var sTitle = _stripTags(col.sTitle);
 			var th = col.nTh;
 	
 			// IE7 is throwing an error when setting these properties with jQuery's


### PR DESCRIPTION
Potential fix for [https://github.com/VarshithRegonda/ecommerce/security/code-scanning/43](https://github.com/VarshithRegonda/ecommerce/security/code-scanning/43)

To correctly sanitize the `col.sTitle` string and avoid incomplete multi-character tag removal, the safest approach is to repeatedly apply the tag-removal replacement until no tags remain. Alternatively, use a well-tested tag-stripping function/library. Since we should not change functionality or add new dependencies in this context, the recommended solution is to replace `/<.*?>/g` with a loop or a function that strips all `<...>` tags until none remain. This involves updating the sanitization in line 6074, possibly by wrapping it into a small helper function defined within the file.

Specifically:
- Add a local function `_stripTags(s)` that repeatedly strips tags.
- Replace `col.sTitle.replace(/<.*?>/g, "")` with `_stripTags(col.sTitle)`.
- Insert the helper function at a suitable point above `_fnSortAria`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
