### PR TITLE
Potential fix for code scanning alert no. 44: Incomplete multi-character sanitization

### DIFF
--- a/Ecommerce-Template-Bootstrap-master/Ecommerce-Template-Bootstrap-master/js/addons/datatables.js
+++ b/Ecommerce-Template-Bootstrap-master/Ecommerce-Template-Bootstrap-master/js/addons/datatables.js
@@ -14723,9 +14723,17 @@
 			return _empty(data) ?
 				data :
 				typeof data === 'string' ?
-					data
-						.replace( _re_new_lines, " " )
-						.replace( _re_html, "" ) :
+					(function stripAllTags(str) {
+						if (typeof str !== "string") return str;
+						str = str.replace(_re_new_lines, " ");
+						let old;
+						do {
+							old = str;
+							str = str.replace(_re_html, "");
+						} while (str !== old);
+						return str;
+					})(data)
+					:
 					'';
 		},
 	


### PR DESCRIPTION
Potential fix for [https://github.com/VarshithRegonda/ecommerce/security/code-scanning/44](https://github.com/VarshithRegonda/ecommerce/security/code-scanning/44)

**General fix:**  
The core problem is that `/</.*?>/g` does not recursively remove all tag-like substrings if nested or malformed tags are present, leaving tag brackets behind. Typical fixes:  
- Apply the regex repeatedly until no more replacements occur, **or**  
- Use a well-tested HTML sanitizer library.

**Best fix for this context:**  
Since the fix needs to be in vanilla JS in the existing code, and external dependencies are not present, we should:
- Apply the regex recursively until no more replacements happen.  
This matches both best practices and the project's current approach.

**Implementation:**  
- In `DataTable.ext.type.search.html`, replace `.replace(_re_html, "")` with a loop that repeatedly removes tags until none are left.
- Do **not** modify `_re_html`’s definition.
- Fix only this spot (line 14726–14728).
- No imports are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
