### PR TITLE
Potential fix for code scanning alert no. 42: Incomplete multi-character sanitization

### DIFF
--- a/Ecommerce-Template-Bootstrap-master/Ecommerce-Template-Bootstrap-master/js/addons/datatables.js
+++ b/Ecommerce-Template-Bootstrap-master/Ecommerce-Template-Bootstrap-master/js/addons/datatables.js
@@ -5820,7 +5820,10 @@
 	
 		for ( var i=0, ien=settings.aoData.length ; i<ien ; i++ ) {
 			s = _fnGetCellData( settings, i, colIdx, 'display' )+'';
-			s = s.replace( __re_html_remove, '' );
+			do {
+				var prev = s;
+				s = s.replace( __re_html_remove, '' );
+			} while (prev !== s);
 			s = s.replace( /&nbsp;/g, ' ' );
 	
 			if ( s.length > max ) {


### PR DESCRIPTION
Potential fix for [https://github.com/VarshithRegonda/ecommerce/security/code-scanning/42](https://github.com/VarshithRegonda/ecommerce/security/code-scanning/42)

The main issue is that the regular expression replacement may not remove all instances of potentially malicious content, such as nested, malformed, or repeated tags. To fix this, we should use a well-tested HTML sanitization library if possible. However, since we **cannot add external dependencies** within this single file and must restrict edits to the shown code, the next best generic fix is to repeatedly apply the regular expression substitution until the HTML tags are fully removed, as per the CodeQL guidance.

We'll change the line  
`s = s.replace( __re_html_remove, '' );`  
so that it applies the replacement in a loop until no further replacements are possible.

**Required changes:**
- In `_fnGetMaxLenString`, replace the single call with a do-while loop for repeated replacement.

No new imports or helpers are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
