### PR TITLE
Potential fix for code scanning alert no. 41: Incomplete multi-character sanitization

### DIFF
--- a/Ecommerce-Template-Bootstrap-master/Ecommerce-Template-Bootstrap-master/js/addons/datatables.js
+++ b/Ecommerce-Template-Bootstrap-master/Ecommerce-Template-Bootstrap-master/js/addons/datatables.js
@@ -1528,7 +1528,12 @@
 	
 	
 	var _stripHtml = function ( d ) {
-		return d.replace( _re_html, '' );
+		var prev;
+		do {
+			prev = d;
+			d = d.replace(_re_html, '');
+		} while (d !== prev);
+		return d;
 	};
 	
 	


### PR DESCRIPTION
Potential fix for [https://github.com/VarshithRegonda/ecommerce/security/code-scanning/41](https://github.com/VarshithRegonda/ecommerce/security/code-scanning/41)

To robustly sanitize HTML from strings (and avoid incomplete multi-character pattern replacement), it's best to use a well-tested sanitization library. However, if this is not possible due to project constraints or code footprint (as in this context—where only this snippet can be edited), a strong fallback is to repeatedly apply the regex until no changes are detected, ensuring all tags are stripped, even if newly adjacent delimiters arise due to a prior replacement.

For this project, update the `_stripHtml` function in `Ecommerce-Template-Bootstrap-master/js/addons/datatables.js` (lines 1530-1532). Replace the single-pass `.replace` with a loop that continues replacing until the output no longer changes. No new methods or imports are needed; just update the definition of `_stripHtml` to include this repeated replacement logic.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
